### PR TITLE
Issue merging

### DIFF
--- a/R/generateSigma.R
+++ b/R/generateSigma.R
@@ -188,6 +188,6 @@ generateSigma <- function(
            call. = FALSE)
     }
   } else {
-    list(Sigma, path_matrix)
+    Sigma
   }
 }

--- a/R/generateSigma.R
+++ b/R/generateSigma.R
@@ -188,6 +188,6 @@ generateSigma <- function(
            call. = FALSE)
     }
   } else {
-    Sigma
+    list(Sigma, path_matrix)
   }
 }

--- a/R/generatecSEMModel.r
+++ b/R/generatecSEMModel.r
@@ -173,7 +173,6 @@ generatecSEMModel <- function(
     if(!is.null(Phi_coefs)) {
       coef_df <- merge(coef_df, Phi_coefs, sort = FALSE)
     }
-
   } else if(!is.null(error_coefs)) {
     coef_df <- error_coefs
     if(!is.null(Phi_coefs)) {
@@ -191,10 +190,10 @@ generatecSEMModel <- function(
   ## Combine Structural, measurement/composite and error correlation matrices
   ## and add the rest of the information
   sme <-
-    unlist(lapply(sl, function(s) {
-      unlist(lapply(ml, function(m) {
-        unlist(lapply(el, function(e) {
-          lapply(Phil, function(Phi) {
+    unlist(lapply(Phil, function(Phi){
+      unlist(lapply(el, function(e) {
+        unlist(lapply(ml, function(m) {
+          lapply(sl, function(s){
             l <- list(
               "structural"  = xx$structural,
               "measurement" = xx$measurement,


### PR DESCRIPTION
The order of the two list in the ``model_list`` object were different. The ``Coef_df`` dataframe was being created via if-else-statements and the `merge(...)` function. The merging happend in this order: path_coefs, then measurement_coefs, then error-coeffs and Phi-coeffs. 
This small example shows that the resulting dataframe will iterate over the different values of the combinations of  path_coefs, measurement_coefs, error-coeffs for the same value for Phi. After that it will iterate over error-coeff and so on.  
```
df_path <- data.frame(a = c(0, 1, 2, 3, 4, 5), b = c(0, 1, 2, 3, 4, 5))
df_measurement <- data.frame(e = c(0, 1, 2, 3, 4, 5), d = c(0, 1, 2, 3, 4, 5))
df_error <- data.frame(g = c(0, 1, 2, 3, 4, 5), f = c(0, 1, 2, 3, 4, 5))
df_phi <- data.frame(h = c(0, 1, 2, 3, 4, 5))

test_df <- merge(df_path, df_measurement, sort = FALSE)
test_df2 <- merge(test_df, df_error,  sort = FALSE)
test_df3 <- merge(test_df2, df_phi,  sort = FALSE)
```
On the other hand the object "Models" uses `lapply(..)` to create a list containing all information for performing the data generating process. It will iterate through every value for path-coefficients then error, then measuremt then Phi, creating a different order than the object coef_df. 

This will result that the combination in the model_list object will be different. 

I changed the order of the `lapply(...)` chain such that it will iterate through every Phi value then measurement, erro and then path coefficient creating the same order of the `merge(...)` and if-else-statements of the ``Coef_df`` object. 
